### PR TITLE
Python 3.x compatibility + live endpoint updated

### DIFF
--- a/oandapy.py
+++ b/oandapy.py
@@ -276,8 +276,8 @@ class Streamer():
                     break
 
                 if line:
-                    data = json.loads(line)
-                    if not (ignore_heartbeat and data.has_key("heartbeat")):
+                    data = json.loads(line.decode("utf-8"))
+                    if not (ignore_heartbeat and "heartbeat" in data):
                         self.on_success(data)
 
 

--- a/oandapy.py
+++ b/oandapy.py
@@ -243,7 +243,7 @@ class Streamer():
         if environment == 'practice':
             self.api_url = 'https://stream-fxpractice.oanda.com/v1/prices'
         elif environment == 'live':
-            self.api_url = 'https://stream-fxtrade.oanda.com/v1/quote'
+            self.api_url = 'https://stream-fxtrade.oanda.com/v1/prices'
 
         self.access_token = access_token
         self.client = requests.Session()


### PR DESCRIPTION
To make `oandapy.py` compatible with **Python 3.x**, I had to change lines `279-280` from:

```
data = json.loads(line)
if not (ignore_heartbeat and data.has_key("heartbeat")):
    ...
```
to
```
data = json.loads(line.decode("utf-8"))
if not (ignore_heartbeat and "heartbeat" in data):
    ...
```
.
Also, line `246` had to update the live api endpoint from
```
self.api_url = 'https://stream-fxtrade.oanda.com/v1/quotes'
```
to
```
self.api_url = 'https://stream-fxtrade.oanda.com/v1/prices'
```