### PR TITLE
new style class

### DIFF
--- a/oandapy.py
+++ b/oandapy.py
@@ -265,7 +265,7 @@ class API(EndpointsMixin, object):
 
 """HTTPS Streaming"""
 
-class Streamer():
+class Streamer(object):
     """ Provides functionality for HTTPS Streaming
     Docs: http://developer.oanda.com/docs/v1/stream/#rates-streaming
     """


### PR DESCRIPTION
-   Derived classes can use super() only on new-style classes
-   Old-style classes are not supported in python 3
-   to be consistent with the other class defs in the file