### PR TITLE
Fix "'response' referenced before assignment"

### DIFF
--- a/oandapy/oandapy.py
+++ b/oandapy/oandapy.py
@@ -264,9 +264,11 @@ class API(EndpointsMixin, object):
 
         try:
             response = func(url, **request_args)
+            content = response.content.decode('utf-8')
         except requests.RequestException as e:
             print (str(e))
-        content = response.content.decode('utf-8')
+            content = dict(error=str(e))
+
 
         content = json.loads(content)
 


### PR DESCRIPTION
The try/except block in `request()` causes `response` and `content` to be referenced before assignment.  I moved some code into the `try` block and added a line in `except` to cause meaningful information to be passed back to user in response, and prevent the use of `response` before assignment

```
Traceback (most recent call last):
 ...
  File "oandapy/oandapy.py", line 38, in get_history
    return self.request(endpoint, params=params)
  File "oandapy/oandapy.py", line 269, in request
    content = response.content.decode('utf-8')
UnboundLocalError: local variable 'response' referenced before assignment
```