### PR TITLE
autochartist of forexlabs endpoint

### DIFF
--- a/oandapy/oandapy.py
+++ b/oandapy/oandapy.py
@@ -204,6 +204,13 @@ class EndpointsMixin(object):
         endpoint = 'labs/v1/orderbook_data'
         return self.request(endpoint, params=params)
 
+    def get_autochartist(self, **params):
+        """Returns 'Our favourites; signals from Autochartist.
+        Docs: http://developer.oanda.com/rest-live/forex-labs/
+        """
+        endpoint = '/labs/v1/signal/autochartist'
+        return self.request(endpoint, params=params)
+
 
 """ Provides functionality for access to core OANDA API calls """
 


### PR DESCRIPTION
to cover missing autochartist of the forexlabs endpoint: #36 

``` python
import oandapy
import json

oanda = oandapy.API(environment="practice", access_token="")

response = oanda.get_autochartist(instruments="EUR_USD")
print json.dumps(response, indent=2)
```
